### PR TITLE
Bootleg Upgrade Aquatic and Wild Update mechanics.

### DIFF
--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/black_sandgen.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/black_sandgen.json
@@ -1,0 +1,26 @@
+{
+  "growth_chance": 1,
+  "growth_for_face": [
+    {
+      "direction": "down",
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "biomesoplenty:black_sand"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "biomesoplenty:black_sandstone"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "minecraft:bubble_column"
+  }
+}

--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/bop_mud.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/bop_mud.json
@@ -1,0 +1,47 @@
+{
+  "area_condition": {
+    "type": "generate_if_not_too_many",
+    "radiusX": 3,
+    "radiusY": 2,
+    "radiusZ": 3,
+    "requiredAmount": 12,
+    "must_have": {
+      "predicate_type": "immersive_weathering:fluid_match",
+      "fluid": "minecraft:water"
+    }
+  },
+  "growth_chance": 0.5,
+  "position_predicates": [
+    {
+      "predicate_type": "biome_match",
+      "biomes": [
+	    "#forge:is_swamp",
+	    "biomesoplenty:bayou",
+	    "biomesoplenty:bog",
+	    "biomesoplenty:marsh"
+	  ]
+    }
+  ],
+  "growth_for_face": [
+    {
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "biomesoplenty:mud"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "biomesoplenty:mud"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "minecraft:dirt"
+  }
+}

--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/clay_from_mud.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/clay_from_mud.json
@@ -1,0 +1,39 @@
+{
+  "area_condition": {
+    "type": "neighbor_based_generation",
+    "must_have": {
+      "predicate_type": "immersive_weathering:block_set_match",
+      "blocks": [
+        "minecraft:dripstone_block",
+        "minecraft:pointed_dripstone"
+      ]
+    },
+    "directions": [
+      "down"
+    ]
+  },
+  "growth_chance": 1,
+  "growth_for_face": [
+    {
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "minecraft:clay"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "biomesoplenty:mud"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "biomesoplenty:mud"
+  },
+  "target_self": true
+}

--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/gravelgen.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/gravelgen.json
@@ -1,0 +1,28 @@
+{
+  "growth_chance": 1,
+  "growth_for_face": [
+    {
+      "direction": "down",
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "minecraft:gravel"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "minecraft:cobblestone",
+    "minecraft:cobbled_deepslate",
+    "minecraft:mossy_cobblestone"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "minecraft:bubble_column"
+  }
+}

--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/orange_sandgen.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/orange_sandgen.json
@@ -1,0 +1,26 @@
+{
+  "growth_chance": 1,
+  "growth_for_face": [
+    {
+      "direction": "down",
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "biomesoplenty:orange_sand"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "biomesoplenty:orange_sandstone"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "minecraft:bubble_column"
+  }
+}

--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/red_sandgen.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/red_sandgen.json
@@ -1,0 +1,26 @@
+{
+  "growth_chance": 1,
+  "growth_for_face": [
+    {
+      "direction": "down",
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "minecraft:red_sand"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "minecraft:red_sandstone"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "minecraft:bubble_column"
+  }
+}

--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/sandgen.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/sandgen.json
@@ -1,0 +1,26 @@
+{
+  "growth_chance": 1,
+  "growth_for_face": [
+    {
+      "direction": "down",
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "minecraft:sand"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "minecraft:sandstone"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "minecraft:bubble_column"
+  }
+}

--- a/config/openloader/data/bliss_data_v2/data/bliss/block_growths/white_sandgen.json
+++ b/config/openloader/data/bliss_data_v2/data/bliss/block_growths/white_sandgen.json
@@ -1,0 +1,26 @@
+{
+  "growth_chance": 1,
+  "growth_for_face": [
+    {
+      "direction": "down",
+      "weight": 1,
+      "growth": [
+        {
+          "data": {
+            "block": {
+              "Name": "biomesoplenty:white_sand"
+            }
+          },
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "owners": [
+    "biomesoplenty:white_sandstone"
+  ],
+  "replacing_target": {
+    "predicate_type": "minecraft:block_match",
+    "block": "minecraft:bubble_column"
+  }
+}


### PR DESCRIPTION
-Sand and Gravel can be generated underneath Sandstone and Cobbles respectively when they have a bubble column under them. (This includes red and bop sands)
-Mud spreads onto dirt when in contact with water and in swampy biomes.
-Mud can be dehydrated into Clay with Dripstone.