### PR TITLE
Fix unix setup script and server readme

### DIFF
--- a/ship/SERVER_README.txt
+++ b/ship/SERVER_README.txt
@@ -7,20 +7,20 @@ Installation Instructions
 		If you're unsure what version you have, open
 		a Command Prompt and run 
 				java -version
-		If it does not say the version is "1.17.0_(number)"
-		you have to  install Java 8
+		If it does not say the version is "17.0.(number)"
+		you have to install Java 17
 
 	- Run the server setup script for your OS
-		WINDOWS: Run setup_server.bat
-		MAC/LINUX: Run setup_server.sh
+		WINDOWS: Run "setup_server.bat"
+		MAC/LINUX: Run "setup_server.sh"
 
 	- Wait for the pack to download
 
-	- Run the server via the forge-1.18.2...jar
-		WARNING: DO NOT Run forge-installer.jar or
-		minecraft_server.1.18.2.jar 
+	- Start the server with the script for your OS
+		WINDOWS: Run "run.bat"
+		MAC/LINUX: Run "run.sh"
 
-	- Accept the Minecraft EULA
+	- Accept the Minecraft EULA in "eula.txt"
 
 	- Run the server again
 

--- a/ship/setup_server.sh
+++ b/ship/setup_server.sh
@@ -1,20 +1,30 @@
+#!/bin/bash
+
 if [[ -f forge-installer.jar ]]; then
-    echo forge-installer.jar is present, which indicates the pack is already installed.
-	echo Delete forge-installer.jar if you intended to install or if the previous installation stopped halfway.
+	echo "forge-installer.jar is present, which indicates the pack is already installed."
+	echo "Delete forge-installer.jar if you intended to install or if the previous installation stopped halfway."
 	read -n 1 -s -r -p "Press any key to continue..."
-	exit 0
+	exit 1
 fi
 
-if [[ $(java -version 2>&1 | awk -F '"' '/version/ {print $2}') < "17" ]];then 
-    echo Java is too old.;
-    exit 0
+if [[ $(java -version 2>&1 | awk -F '"' '/version/ {print $2}') < "17" ]]; then 
+	echo "Java is too old."
+	exit 1
 fi
 
 mkdir mods
-echo Downloading modpack files...
-cat mods.csv | sed -r 's/\r//g' | sed -r 's/(.+),(.+)/-c "wget -c \1 -O \2"/g' | xargs -n2 bash
+echo "Downloading modpack files..."
+if command -v wget > /dev/null; then
+	cat mods.csv | sed -r 's/\r//g' | sed -r 's/(.+),(.+)/-c "wget -c \1 -O \2"/g' | xargs -n2 bash
+elif command -v curl > /dev/null; then
+	cat mods.csv | sed -r 's/\r//g' | sed -r 's/(.+),(.+)/-c "curl -L -C - \1 -o \2"/g' | xargs -n2 bash
+else
+	echo "No downloading command found."
+	echo "Install `curl` or `wget` and try again."
+	exit 1
+fi
 
-echo Installing server...
+echo "Installing server..."
 java -jar forge-installer.jar --installServer
 
 read -n 1 -s -r -p "Press any key to continue..."


### PR DESCRIPTION
Updates the server readme to remove outdated information and patches the setup script to use curl if wget is not available.

I also tried to change its line endings to LF but i'm not sure git picked it up. I tried a couple ways of doing it but none of them seemed to work