### PR TITLE
Add Create compat

### DIFF
--- a/config/openloader/resources/bliss_resources/assets/create/lang/en_us.json
+++ b/config/openloader/resources/bliss_resources/assets/create/lang/en_us.json
@@ -1,0 +1,22 @@
+{
+		"item.create.wrench": "Mechanic's Wrench",
+		
+		"block.create.cut_limestone": "Cut Marble",
+		"block.create.cut_limestone_brick_slab": "Cut Marble Brick Slab",
+		"block.create.cut_limestone_brick_stairs": "Cut Marble Brick Stairs",
+		"block.create.cut_limestone_brick_wall": "Cut Marble Brick Wall",
+		"block.create.cut_limestone_bricks": "Cut Marble Bricks",
+		"block.create.cut_limestone_slab": "Cut Marble Slab",
+		"block.create.cut_limestone_stairs": "Cut Marble Stairs",
+		"block.create.cut_limestone_wall": "Cut Marble Wall",
+		"block.create.layered_limestone": "Layered Marble",
+		"block.create.limestone": "Marble",
+		"block.create.polished_cut_limestone": "Polished Cut Marble",
+		"block.create.polished_cut_limestone_slab": "Polished Cut Marble Slab",
+		"block.create.polished_cut_limestone_stairs": "Polished Cut Marble Stairs",
+		"block.create.polished_cut_limestone_wall": "Polished Cut Marble Wall",
+		"block.create.small_limestone_brick_slab": "Small Marble Brick Slab",
+		"block.create.small_limestone_brick_stairs": "Small Marble Brick Stairs",
+		"block.create.small_limestone_brick_wall": "Small Marble Brick Wall",
+		"block.create.small_limestone_bricks": "Small Marble Bricks"
+}

--- a/config/openloader/resources/bliss_resources/assets/excavated_variants/lang/en_us.json
+++ b/config/openloader/resources/bliss_resources/assets/excavated_variants/lang/en_us.json
@@ -1,0 +1,11 @@
+{
+	"block.excavated_variants.create_limestone_lapis_ore": "Marble Lapis Ore",
+	"block.excavated_variants.create_limestone_copper_ore": "Marble Copper Ore",
+	"block.excavated_variants.create_limestone_zinc_ore": "Marble Zinc Ore",
+	"block.excavated_variants.create_limestone_gold_ore": "Marble Gold Ore",
+	"block.excavated_variants.create_limestone_redstone_ore": "Marble Redstone Ore",
+	"block.excavated_variants.create_limestone_coal_ore": "Marble Coal Ore",
+	"block.excavated_variants.create_limestone_emerald_ore": "Marble Emerald Ore",
+	"block.excavated_variants.create_limestone_diamond_ore": "Marble Diamond Ore",
+	"block.excavated_variants.create_limestone_iron_ore": "Marble Iron Ore"
+}

--- a/config/openloader/resources/bliss_vmct/assets/quark/models/tiny_potato/autism_creature.json
+++ b/config/openloader/resources/bliss_vmct/assets/quark/models/tiny_potato/autism_creature.json
@@ -1,0 +1,3 @@
+{
+  "parent": "quark:tiny_potato/yippee"
+}

--- a/config/openloader/resources/bliss_vmct/assets/quark/models/tiny_potato/yipee.json
+++ b/config/openloader/resources/bliss_vmct/assets/quark/models/tiny_potato/yipee.json
@@ -1,0 +1,3 @@
+{
+  "parent": "quark:tiny_potato/yippee"
+}

--- a/config/openloader/resources/bliss_vmct/assets/quark/models/tiny_potato/yippee.json
+++ b/config/openloader/resources/bliss_vmct/assets/quark/models/tiny_potato/yippee.json
@@ -1,0 +1,95 @@
+{
+	"credit": "Made with Blockbench",
+	"parent": "minecraft:block/cube_all",
+	"textures": {
+		"all": "quark:model/tiny_potato/template"
+	},
+	"elements": [
+		{
+			"from": [6, 3, 6],
+			"to": [10, 6, 10],
+			"faces": {
+				"north": {"uv": [4, 4, 8, 8], "texture": "#all"},
+				"east": {"uv": [0, 4, 4, 8], "texture": "#all"},
+				"south": {"uv": [12, 4, 16, 8], "texture": "#all"},
+				"west": {"uv": [8, 4, 12, 8], "texture": "#all"},
+				"up": {"uv": [8, 4, 4, 0], "texture": "#all"},
+				"down": {"uv": [12, 4, 8, 0], "texture": "#all"}
+			}
+		},
+		{
+			"name": "body",
+			"from": [6, 1, 6],
+			"to": [12, 3, 10],
+			"faces": {
+				"north": {"uv": [4, 8.5, 8, 10], "texture": "#all"},
+				"east": {"uv": [0, 8.5, 4, 10], "texture": "#all"},
+				"south": {"uv": [12, 8.5, 16, 10], "texture": "#all"},
+				"west": {"uv": [8, 8.5, 12, 10], "texture": "#all"},
+				"up": {"uv": [8, 4, 4, 0], "texture": "#all"},
+				"down": {"uv": [12, 4, 8, 0], "texture": "#all"}
+			}
+		},
+		{
+			"name": "leg1",
+			"from": [6, 0, 6],
+			"to": [7, 1, 7],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [6.5, 0.5, 6.5]},
+			"faces": {
+				"north": {"uv": [4, 8.5, 8, 10], "texture": "#all"},
+				"east": {"uv": [0, 8.5, 4, 10], "texture": "#all"},
+				"south": {"uv": [12, 8.5, 16, 10], "texture": "#all"},
+				"west": {"uv": [8, 8.5, 12, 10], "texture": "#all"},
+				"up": {"uv": [8, 4, 4, 0], "texture": "#all"},
+				"down": {"uv": [12, 4, 8, 0], "texture": "#all"}
+			}
+		},
+		{
+			"name": "leg2",
+			"from": [11, 0, 6],
+			"to": [12, 1, 7],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 0.5, 6.5]},
+			"faces": {
+				"north": {"uv": [4, 8.5, 8, 10], "texture": "#all"},
+				"east": {"uv": [0, 8.5, 4, 10], "texture": "#all"},
+				"south": {"uv": [12, 8.5, 16, 10], "texture": "#all"},
+				"west": {"uv": [8, 8.5, 12, 10], "texture": "#all"},
+				"up": {"uv": [8, 4, 4, 0], "texture": "#all"},
+				"down": {"uv": [12, 4, 8, 0], "texture": "#all"}
+			}
+		},
+		{
+			"name": "leg3",
+			"from": [11, 0, 9],
+			"to": [12, 1, 10],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [11.5, 0.5, 9.5]},
+			"faces": {
+				"north": {"uv": [4, 8.5, 8, 10], "texture": "#all"},
+				"east": {"uv": [0, 8.5, 4, 10], "texture": "#all"},
+				"south": {"uv": [12, 8.5, 16, 10], "texture": "#all"},
+				"west": {"uv": [8, 8.5, 12, 10], "texture": "#all"},
+				"up": {"uv": [8, 4, 4, 0], "texture": "#all"},
+				"down": {"uv": [12, 4, 8, 0], "texture": "#all"}
+			}
+		},
+		{
+			"name": "leg4",
+			"from": [6, 0, 9],
+			"to": [7, 1, 10],
+			"rotation": {"angle": -22.5, "axis": "y", "origin": [6.5, 0.5, 9.5]},
+			"faces": {
+				"north": {"uv": [4, 8.5, 8, 10], "texture": "#all"},
+				"east": {"uv": [0, 8.5, 4, 10], "texture": "#all"},
+				"south": {"uv": [12, 8.5, 16, 10], "texture": "#all"},
+				"west": {"uv": [8, 8.5, 12, 10], "texture": "#all"},
+				"up": {"uv": [8, 4, 4, 0], "texture": "#all"},
+				"down": {"uv": [12, 4, 8, 0], "texture": "#all"}
+			}
+		}
+	],
+	"display": {
+		"head": {
+			"translation": [0, 14.5, 0]
+		}
+	}
+}

--- a/scripts/create_compat.zs
+++ b/scripts/create_compat.zs
@@ -1,0 +1,150 @@
+#priority 90
+
+// Create integration by Partonetrain, lines 6-14 are from MobiusFlip's Crucial 2 Create compat script
+#onlyif modloaded create
+	#onlyif modnotloaded createtweaker
+	import crafttweaker.api.events.CTEventManager;
+	CTEventManager.register<crafttweaker.api.event.entity.player.PlayerLoggedInEvent>((event) => {
+		var player = event.player;
+		player.sendMessage("WARNING: Create Integration!");
+		player.sendMessage("CreateTweaker is required for Create integration to work properly. Please make sure you have the latest version installed:");
+		player.sendMessage("https://www.curseforge.com/minecraft/mc-mods/createtweaker");
+		player.sendMessage(" ");
+		player.sendMessage("IMPORTANT: This world needs to either be recreated, or the Create datapack's priority lowered to work, as you've loaded it without CreateTweaker.");
+	});
+
+	#endif
+
+#onlyif modloaded createtweaker
+import mods.create.CrushingManager;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.util.random.Percentaged;
+
+
+println("Create detected. Loading Create Compat!");
+
+
+// Excavated Variants Crusher ===============================================================================
+
+for item in <tag:items:forge:ores>.elements {
+	var amount = 1;
+	if("excavated_variants" in ((item as IItemStack).registryName as string)){
+		if("copper" in ((item as IItemStack).registryName as string)){
+			amount = 5;
+		}
+		if("redstone" in ((item as IItemStack).registryName as string)){
+			amount = 6;
+		}	
+		if("lapis" in ((item as IItemStack).registryName as string)){
+			amount = 10;
+		}	
+
+		AddCrusherRecipe(item, GetOreItemFromOreBlock(item), amount, GetStoneFromOreBlock(item));
+	}
+}
+
+function GetStoneFromOreBlock(oreBlock as IItemStack) as IItemStack{
+	if ("create_crimsite" in (oreBlock.registryName as string)){
+		return <item:create:crimsite>;
+	}
+	if ("create_limestone"  in (oreBlock.registryName as string)){
+		return <item:create:limestone>;
+	}
+	if ("calcite" in (oreBlock.registryName as string)){
+		return <item:minecraft:calcite>;
+	}
+	if ("create_scoria" in (oreBlock.registryName as string)){
+		return <item:create:scoria>;
+	}
+	if ("quark_shales" in (oreBlock.registryName as string)){
+		return <item:quark:shale>;
+	}
+	if ("quark_jasper"  in (oreBlock.registryName as string)){
+		return <item:quark:jasper>;
+	}
+	if ("quark_limestone" in (oreBlock.registryName as string)){
+		return <item:quark:limestone>;
+	}
+	if ("create_ochrum" in (oreBlock.registryName as string)){
+		return <item:create:ochrum>;
+	}
+	if ("granite" in (oreBlock.registryName as string)){
+		return <item:minecraft:granite>;
+	}
+	if ("dripstone" in (oreBlock.registryName as string) ){
+		return <item:minecraft:dripstone_block>;
+	}
+	if ("tuff" in (oreBlock.registryName as string) ){
+		return <item:minecraft:tuff>;
+	}
+	if ("create_veridium" in (oreBlock.registryName as string)){
+		return <item:create:veridium>;
+	}
+	if ("diorite" in (oreBlock.registryName as string)){
+		return <item:minecraft:diorite>;
+	}
+	if ("andesite" in (oreBlock.registryName as string)){
+		return <item:minecraft:andesite>;
+	}
+	if ("create_asurine" in (oreBlock.registryName as string)){
+		return <item:create:asurine>;
+	}
+	if ("create_scorchia" in (oreBlock.registryName as string)){
+		return <item:create:scorchia>;
+	}
+	if ("blackstone" in (oreBlock.registryName as string)){
+		return <item:minecraft:blackstone>;
+	}
+	if ("smooth_basalt" in (oreBlock.registryName as string)){
+		return <item:minecraft:smooth_basalt>;
+	}
+
+	println((oreBlock.registryName as string) + " fell through GetStoneFromOreBlock!");
+	return <item:minecraft:barrier>;
+}
+
+function GetOreItemFromOreBlock(oreBlock as IItemStack) as IItemStack{
+	if ("coal_ore" in (oreBlock.registryName as string)){
+		return <item:minecraft:coal>;
+	}
+	if ("iron_ore" in (oreBlock.registryName as string)){
+		return <item:create:crushed_iron_ore>;
+	}
+	if ("copper_ore" in (oreBlock.registryName as string)){
+		return <item:create:crushed_copper_ore>; 
+	}
+	if ("gold_ore" in (oreBlock.registryName as string)){
+		return <item:create:crushed_gold_ore>;
+	}
+	if ("redstone_ore" in (oreBlock.registryName as string)){
+		return <item:minecraft:redstone>; 
+	}
+	if ("emerald_ore" in (oreBlock.registryName as string)){
+		return <item:minecraft:emerald>;
+	}
+	if ("lapis_ore" in (oreBlock.registryName as string)){
+		return <item:minecraft:lapis_lazuli>; 
+	}
+	if ("diamond_ore" in (oreBlock.registryName as string)){
+		return <item:minecraft:diamond>;
+	}
+	if ("zinc_ore" in (oreBlock.registryName as string)){
+		return <item:create:crushed_zinc_ore>;
+	}
+	if("quartz_ore" in  (oreBlock.registryName as string)){
+		return <item:minecraft:quartz>;
+	}
+
+	println((oreBlock.registryName as string) + " fell through GetOreItemFromOreBlock!");
+	return <item:minecraft:barrier>;
+}
+
+function AddCrusherRecipe(oreBlock as IItemStack, crushedOre as IItemStack, amt as int, stone as IItemStack) as void{
+	println("Added crusher recipe for " + (oreBlock.registryName as string));
+	var output = [crushedOre * amt, (crushedOre % 75), (<item:create:experience_nugget> % 75), stone % 12] as Percentaged<IItemStack>[];
+	var recipeName = "crushed_" + oreBlock.descriptionId;
+	<recipetype:create:crushing>.addRecipe(recipeName, output, oreBlock, 250);
+}
+
+#endif
+#endif


### PR DESCRIPTION
All ore variants (ie, copper andesite ore) can be used in Create's Crusher.
Create Limestone renamed to Marble.
Create Wrench renamed to Mechanic's Wrench.
Updated VioletMoonCommunityTaters as well (add yippee tater)

Do note, Create crashes with Oculus shaders.
Additionally, Create is not nerfed in any way like it is in Crucial 2.