### PR TITLE
added de_de version of the blissguide

### DIFF
--- a/patchouli_books/blissguide/de_de/categories/gossip.json
+++ b/patchouli_books/blissguide/de_de/categories/gossip.json
@@ -1,0 +1,6 @@
+{
+	"name": "Lissas Ratschläge",
+	"description": "$(lissa)Lissa$() wird ab und zu vorbeischauen, wenn Du Ziele im Modpack erreichst, und Dich über coole Features beraten, die Du ausprobieren solltest.$(br2)Halte Ausschau nach dem $(#ff0000)(!)$() auf dem Handbuch in deinem Inventar!",
+	"icon": "minecraft:compass",
+	"sortnum": 1
+}

--- a/patchouli_books/blissguide/de_de/categories/intro.json
+++ b/patchouli_books/blissguide/de_de/categories/intro.json
@@ -1,0 +1,6 @@
+{
+	"name": "Die Grundlagen",
+	"description": "Lerne hier die Grundlagen des $(thing)Bliss$() Modpack!$(br2)Zusätzliche wichtige Informationen werden im Laufe der Zeit angezeigt, während Du weiter spielst.",
+	"icon": "minecraft:filled_map",
+	"sortnum": 0
+}

--- a/patchouli_books/blissguide/de_de/categories/vanilla_changes.json
+++ b/patchouli_books/blissguide/de_de/categories/vanilla_changes.json
@@ -1,0 +1,6 @@
+{
+	"name": "Vanilla Änderungen",
+	"description": "Dieser Abschnitt zeigt einige wenige wichtige Änderungen am Vanilla-Spiel auf.$(br2)Mach Dir keine Sorgen, alle diese Änderungen auf einmal durchzulesen – aber wenn Dir etwas anders vorkommt als du es gewohnt bist, schau hier ruhig noch einmal rein.",
+	"icon": "minecraft:writable_book",
+	"sortnum": 2
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/animal_transport.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/animal_transport.json
@@ -1,0 +1,18 @@
+{
+	"name": "Tiere auf Reisen",
+	"icon": "minecraft:feather",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:husbandry/breed_an_animal",
+	"pages": [
+		{
+			"type": "patchouli:gossip_game",
+			"title": "Tiere auf Reisen",
+			"text": "dass du einige kleine Tiere in $(item)Käfigen$() transportieren kannst? Es ist eine einfache Art, sie zu transportieren!"
+		},
+		{
+			"type": "quest",
+			"text": "Stelle einige $(item)Käfige$() her und verwende sie, um kleine Tiere zu transportieren."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/automatic_block_breaking.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/automatic_block_breaking.json
@@ -1,0 +1,18 @@
+{
+	"name": "Automatisches Abbauen",
+	"icon": "minecraft:diamond_pickaxe",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:story/smelt_iron",
+		"pages": [
+		{
+			"type": "patchouli:gossip_book",
+			"title": "Automatisches Abbauen",
+			"text": "dass du $(item)Kolben$() nutzen kannst um Blöcke abzubauen? Es ist sogar ziemlich einfach, du musst nur einen $(thing)Eisenstab$() auf die geschobene Seite stecken"
+		},
+		{
+			"type": "quest",
+			"text": "Finde heraus was ein $(thing)Eisenstab$() ist, und unter Verwendung von $(item)Kolben$(), erstelle eine automatisierte Farm."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/automatic_breeding.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/automatic_breeding.json
@@ -1,0 +1,18 @@
+{
+	"name": "Automatisierte Züchtung",
+	"icon": "minecraft:wheat",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:husbandry/breed_an_animal",
+	"pages": [
+		{
+			"type": "patchouli:gossip_love",
+			"title": "Automatisierte Züchtung",
+			"text": "dass du eine $(thing)Futterstelle$() aufstellen kannst, an der Tiere fressen können, ohne dass du ständig Futter hereinbringen musst?"
+		},
+		{
+			"type": "quest",
+			"text": "Finde heraus, wie man eine $(thing)Futterstelle$() baut, und bringe einige Tiere dazu, sich selbst zu züchten."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/beacon_redirection.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/beacon_redirection.json
@@ -1,0 +1,18 @@
+{
+	"name": "Biegen des Leuchtfeuers",
+	"icon": "minecraft:beacon",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:nether/create_beacon",
+	"pages": [
+		{
+			"type": "patchouli:gossip_camera",
+			"title": "Biegen des Leuchtfeuers",
+			"text": "Wusstest du, dass du $(item)Korundhaufen$() verwenden kannst, um $(item)Leuchtfeuerstrahlen$() umzubiegen?"
+		},
+		{
+			"type": "quest",
+			"text": "Schnapp dir ein paar $(item)Korundhaufen$() um $(item)Leuchtfeuerstrahlen$() durch die Gegend zu schießen!$(br2)Solange der letzte nach oben geht, kannst du ausgefallene Kurven fahren!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/bigger_inventory.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/bigger_inventory.json
@@ -1,0 +1,18 @@
+{
+	"name": "Backpack Rucksack",
+	"icon": "minecraft:chest",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:story/smelt_iron",
+	"pages": [
+		{
+			"type": "patchouli:gossip_book",
+			"title": "Rucksack Backpack",
+			"text": "dass du etwas herstellen kannst, das dir hilft, mehr Sachen mit dir zu tragen? Es ist wirklich schade, dass dein Inventar so klein ist, weißt du?"
+		},
+		{
+			"type": "quest",
+			"text": "Finde einen Weg, wie du deinen Inventarplatz vergrößern kannst.$(br2)Vielleicht könnte es helfen, in deiner $(thing)Suchleiste$() danach zu suchen...?"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/day_skipping.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/day_skipping.json
@@ -1,0 +1,18 @@
+{
+	"name": "Tagträumen",
+	"icon": "minecraft:pink_bed",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:adventure/sleep_in_bed",
+	"pages": [
+		{
+			"type": "patchouli:gossip_book",
+			"title": "Tagträumen",
+			"text": "dass du auf $(item)Hängematten$() schlafen kannst, um den Tag zu überspringen? Es wird nicht einmal deinen Spawnpunkt verändern!"
+		},
+		{
+			"type": "quest",
+			"text": "Entspanne dich auf einer $(item)Hängematte$() und schlafe den ganzen Tag!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/faster_smelting.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/faster_smelting.json
@@ -1,0 +1,18 @@
+{
+	"name": "Flauschiger Ofen",
+	"icon": "minecraft:furnace",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:nether/root",
+	"pages": [
+		{
+			"type": "patchouli:gossip_love",
+			"title": "Flauschiger Ofen",
+			"text": "dass es im $(thing)Nether$() feurig süße Hunde gibt? Wenn du einen zähmst und ihn über einem $(item)Ofen$() ruhen lässt, wird er schneller!"
+		},
+		{
+			"type": "quest",
+			"text": "Zähme einen $(thing)Foxhound$() und bringe ihn nach Hause, um deine Erze schneller zu schmelzen. $(br2)Du kannst sie mit $(item)Kohle$() zähmen, aber du brauchst auch etwas, um dir $(thing)Feuer Resistenz$() zu geben."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/lissa.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/lissa.json
@@ -1,0 +1,16 @@
+{
+	"name": "Sag Hallo zu Lissa!",
+	"icon": "minecraft:poppy",
+	"category": "patchouli:gossip",
+	"priority": true,
+	"read_by_default": false,
+	"pages": [
+		{
+			"type": "patchouli:lissa_full"
+		}, 
+		{
+			"type": "text",
+			"text": "Hi, Ich bin $(lissa)Lissa$()! Ich werde dein Ratgeber für die zusätzlichen Inhalte von $(thing)Bliss$() sein.$(br2)Hier im Abschnitt $(lissa)Lissas Ratschläge$() des Bliss-Handbuchs findest du meine Überlegungen zu meinem Lieblingsfeatures, die Du ausprobieren solltest. $(br2)Im Laufe des Spiels werden weitere Kapitel freigeschaltet, also halte die Augen offen! $(br2)Ich wurde von $(l:https://twitter.com/_crowsaga)$(underline)aice$() gezeichnet und als Gemeinschaftswerk von julinya, aice und vazkii entworfen!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/locating_biomes.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/locating_biomes.json
@@ -1,0 +1,18 @@
+{
+	"name": "Biome finden",
+	"icon": "minecraft:map",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:adventure/trade",
+	"pages": [
+		{
+			"type": "patchouli:gossip_explore",
+			"title": "Biome finden",
+			"text": "dass Kartographen in Dörfern Karten zu bestimmten Biomen verkaufen? Es gibt so viele coole Orte zu finden, du solltest ihnen einen Besuch abstatten!"
+		},
+		{
+			"type": "quest",
+			"text": "Besorg dir einige $(thing)Karten$() zu Biomen und geh auf eine Reise. Vergiss nicht, mir die gefundenen Schätze zu zeigen!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/locating_fortresses.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/locating_fortresses.json
@@ -1,0 +1,18 @@
+{
+	"name": "Festungen lokalisieren",
+	"icon": "minecraft:nether_wart",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:nether/root",
+	"pages": [
+		{
+			"type": "patchouli:gossip_camera",
+			"title": "Festungen lokalisieren",
+			"text": "dass du eine $(thing)Netherfestung$() ziemlich einfach finden kannst? Geh einfach durch ein $(thing)Seelensandtal$(), die Seelen dort tragen den Gegenstand, den du brauchst."
+		},
+		{
+			"type": "quest",
+			"text": "Finde einen Weg, $(thing)Netherfestungen$() im $(thing)Seelensandtal$() zu finden.$(br2)Hierfür musst du vielleicht ein Schwert schwingen, also sei darauf vorbereitet!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/locating_slime_chunks.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/locating_slime_chunks.json
@@ -1,0 +1,18 @@
+{
+	"name": "Slime Chunks finden",
+	"icon": "minecraft:slime_ball",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:story/mine_diamond",
+	"pages": [
+		{
+			"type": "patchouli:gossip_love",
+			"title": "Slime Chunks finden",
+			"text": "dass winzige Schleime $(thing)Slime Chunks$() liiiieben? Wenn Du einen dieser süßen Blobs einfangen kannst, kann er dich vielleicht zu einem Chunk führen?"
+		},
+		{
+			"type": "quest",
+			"text": "Finde einen Weg, wie du winzige Schleime einfangen kannst und nutze sie um herauszufinden wo sie spawnen."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/mob_repelling.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/mob_repelling.json
@@ -1,0 +1,18 @@
+{
+	"name": "Monster Vertreibung",
+	"icon": "minecraft:skeleton_skull",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:nether/get_wither_skull",
+	"pages": [
+		{
+			"type": "patchouli:gossip_explore",
+			"title": "Monster Vertreibung",
+			"text": "dass Monster Angst vor ihren eigenen Köpfen haben? Verrückt! Wenn du einen $(thing)Monsterkopf$() an einen Zaun hängst, laufen sie davon wie Füchse!"
+		},
+		{
+			"type": "quest",
+			"text": "Finde einen Weg, wie du Monster mit ihren Köpfen und Schädeln verscheuchen kannst.$(br2)Jeder weiß, dass $(thing)Wither Skelette$() ständig ihre Schädel fallen lassen. Oh, und $(item)Drachenköpfe$() sind alle billige Fälschungen, also kümmere dich nicht um sie!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/ore_farming.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/ore_farming.json
@@ -1,0 +1,18 @@
+{
+	"name": "Erzanbau",
+	"icon": "minecraft:iron_nugget",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:story/mine_diamond",
+	"pages": [
+		{
+			"type": "patchouli:gossip_camera",
+			"title": "Erzanbau",
+			"text": "dass unter der Erde $(thing)Erz-Schildkröten$() spawnen? Du kannst ihre Erze abbauen, und wenn du sie mit $(item)Leuchtbeeren$() fütterst, wachsen sie nach!"
+		},
+		{
+			"type": "quest",
+			"text": "Nutze $(thing)Erz-Schildkröten$() um Erze zu regenerieren.$(br2)Du kannst sogar Blockabbauer und anderes einsetzen."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/parrot_eggs.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/parrot_eggs.json
@@ -1,0 +1,18 @@
+{
+	"name": "Papageienzucht",
+	"icon": "minecraft:egg",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:husbandry/breed_an_animal",
+	"pages": [
+		{
+			"type": "patchouli:gossip_love",
+			"title": "Papageienzucht",
+			"text": "wenn du deinen $(thing)Papagei$()-Freunden ein paar $(item)Rote-Bete-Samen$() gibst, legen sie vielleicht ein Ei für dich. Wer weiß, wo die herkommen?"
+		},
+		{
+			"type": "quest",
+			"text": "Verwende $(item)Rote-Bete-Samen$() bei Papageien, um ein paar $(item)Papageieneier$() zu erhalten."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/player_heads.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/player_heads.json
@@ -1,0 +1,18 @@
+{
+	"name": "Spielerköpfe",
+	"icon": "minecraft:player_head",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:adventure/kill_a_mob",
+	"pages": [
+		{
+			"type": "patchouli:gossip_explore",
+			"title": "Spielerköpfe",
+			"text": "dass wenn du einen $(thing)Schneegolem$() mit dem Namen eines Spielers benennst und ihn dann von einer $(thing)Hexe$() töten lässt, dieser den Spielerkopf fallen lässt?"
+		},
+		{
+			"type": "quest",
+			"text": "Erhalte einen $(item)Spielerkopf$() deiner Wahl, indem du einen benannten $(thing)Schneegolem$() von einer $(thing)Hexe$() töten lässt."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/reach.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/reach.json
@@ -1,0 +1,18 @@
+{
+	"name": "Größere Reichweite",
+	"icon": "minecraft:piston",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:story/mine_diamond",
+	"pages": [
+		{
+			"type": "patchouli:gossip_game",
+			"title": "Größere Reichweite",
+			"text": "dass du einen besonderen $(thing)Mob$() finden kannst der deine Reichweite erhöht? Sein Hut ermöglicht es!"
+		},
+		{
+			"type": "quest",
+			"text": "Begegne dem besonderen unterirdischen $(thing)Monster$() und hol dir seinen Hut.$(br2)Ich habe es selbst nie gesehen, aber angeblich ist es sehr stark und weiß, wie man kämpft, also lass dich da draußen nicht besiegen!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/return_to_death.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/return_to_death.json
@@ -1,0 +1,18 @@
+{
+	"name": "Zum Todespunkt zurückkehren",
+	"icon": "minecraft:compass",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:nether/root",
+	"pages": [
+		{
+			"type": "patchouli:gossip_game",
+			"title": "Zum Todespunkt zurückkehren",
+			"text": "dass wenn du stirbst, all deine Gegenstände von einem freundlichen $(thing)Totem$() aufbewahrt werden?"
+		},
+		{
+			"type": "quest",
+			"text": "Du kannst einen speziellen $(item)Kompass$() erstellen. Erstelle ihn, um deine Gegenstände zu finden, falls du stirbst."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/sawmill.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/sawmill.json
@@ -1,0 +1,18 @@
+{
+	"name": "Holzschnitzerei",
+	"icon": "corail_woodcutter:oak_woodcutter",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:story/smelt_iron",
+	"pages": [
+		{
+			"type": "patchouli:gossip_game",
+			"title": "Holzschnitzerei",
+			"text": "dass Stein nicht das einzige ist was du mit einer Säge bearbeiten kannst? In der Tat!"
+		},
+		{
+			"type": "quest",
+			"text": "Nutze endlich dein ganzes Holz und versuche dich an einem $(item)Sägewerk$(), um Holzblöcke effizienter in ihre Varianten zu schneiden."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/scalable_storage.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/scalable_storage.json
@@ -1,0 +1,18 @@
+{
+	"name": "Erweiterbarer Speicher",
+	"icon": "minecraft:barrel",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:story/smelt_iron",
+	"pages": [
+		{
+			"type": "patchouli:gossip_book",
+			"title": "Erweiterbarer Speicher",
+			"text": "dass du Gegenstände nicht nur in $(item)Truhen$() aufbewahren kannst? Wenn Du viele Items hast lohnt es sich vielleicht in neue $(thing)Lagerblöcke$() zu investieren."
+		},
+		{
+			"type": "quest",
+			"text": "Finde neue, effiziente Lagermöglichkeiten für deine Habseligkeiten."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/shiba.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/shiba.json
@@ -1,0 +1,18 @@
+{
+	"name": "Bellende Schattenfinder",
+	"icon": "minecraft:torch",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:husbandry/tame_an_animal",
+	"pages": [
+		{
+			"type": "patchouli:gossip_explore",
+			"title": "Bellende Schattenfinder",
+			"text": "dass du ein paar wirklich süße $(thing)Berg-Hunde$() zähmen kannst? Wenn du einen dieser süßen Hunde zähmst, kann dieser dunkle Stellen für dich finden!"
+		},
+		{
+			"type": "quest",
+			"text": "Zähme einen $(thing)Shiba Inu$() in einem Bergbiom und lass ihn dunkle Stellen für dich finden, wo Monster spawnen können, indem du eine $(item)Fackel$() in deiner Hand hältst!."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/gossip/villager_catalogue.json
+++ b/patchouli_books/blissguide/de_de/entries/gossip/villager_catalogue.json
@@ -1,0 +1,18 @@
+{
+	"name": "Dorfbewohner-Katalog",
+	"icon": "minecraft:emerald",
+	"category": "patchouli:gossip",
+	"read_by_default": false,
+	"advancement": "minecraft:adventure/trade",
+	"pages": [
+		{
+			"type": "patchouli:gossip_camera",
+			"title": "Dorfbewohner-Katalog",
+			"text": "dass du einen $(item)Handelsposten-Block$() herstellen kannst? Du kannst ihn dann verwenden, um mit jedem $(thing)Dorfbewohner$() in der Umgebung gleichzeitig zu handeln!"
+		},
+		{
+			"type": "quest",
+			"text": "Werde ein Shopaholic mit dem $(item)Handelsposten-Block$()!"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/chilled_dragon.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/chilled_dragon.json
@@ -1,0 +1,14 @@
+{
+	"name": "End-spannter Drache",
+	"icon": "minecraft:dragon_head",
+	"category": "patchouli:intro",
+    "read_by_default": false,
+    "advancement": "minecraft:story/follow_ender_eye",
+    "sortnum": 7,
+	"pages": [
+        {
+            "type": "text",
+            "text": "Mach dir keine Sorgen um den $(thing)Enderdrachen$(), denn er hat keinen Streit mit dir. Beim Betreten des $(thing)End$() öffnet sich bereits das Rückkehrportal, sowie ein paar $(thing)End Tore$().$(br2)Wenn du aber das Ei willst, nun..."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/jei_intro.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/jei_intro.json
@@ -1,0 +1,37 @@
+{
+	"name": "Einleitung zu JEI",
+	"icon": "minecraft:compass",
+	"category": "patchouli:intro",
+	"priority": true,
+	"sortnum": 2,
+	"pages": [
+		{
+			"type": "text",
+			"text": "Lass uns darüber sprechen, wie du entdecken kannst, welche neuen Inhalte $(thing)Bliss$() zu bieten hat.$(br2)Vielleicht ist dir schon die große Auswahl an Elementen auf der rechten Bildschirmseite aufgefallen wenn du das Inventar öffnest. Wenn Du Modding-Veteran bist, ist das nichts Neues, aber für Euch Neulinge: Das ist ($(item)Just Enough Items$())"
+		},
+		{
+			"type": "text",
+			"text": "Hier siehst du alle relevanten Gegenstände im Spiel. Wir haben uns erlaubt, die nicht relevanten auszublenden. $(br2)Du kannst mit der linken Maustaste auf einen Gegenstand klicken, um zu sehen, wie er hergestellt wird, oder mit der rechten Maustaste, um zu sehen, was daraus hergestellt werden kann. Das Drücken der Tasten $(thing)R$()ezept bzw. N$(thing)U$()tzen hat ebenfalls dieses Verhalten."
+		},
+		{
+			"type": "text",
+			"text": "In $(thing)Bliss$() führen wir jedoch auch einige zusätzliche Systeme ein, die Dir helfen, den gewünschten Inhalt zu finden. $(br2)Du kannst Gegenstände neben ihren Namen auch nach $(thing)Kategorie$(), $(thing)Farbe$() oder beiden gleichzeitig suchen! $(br2)Du kannst zum Beispiel einfach $(item)Red Building Blocks$() eingeben und bekommst genau das auf einem Silbertablett serviert. Cool, nicht wahr?"
+		},
+		{
+			"type": "text",
+			"text": "Einige verfügbare Kategorien sind wie folgt:$(br)$(li)Building Blocks$(li)Decorative Blocks$(li)Variant Blocks$(li)Functional Blocks$(li)Technical Blocks$(li)Crops$(li)Food Items$(li)Utility Items $(br2)Sieh dich in Ruhe um, es gibt noch viele andere Dinge, nach denen du suchen kannst."
+		},
+		{
+			"type": "text",
+			"text": "Sobald du etwas gefunden hast was dir gefällt, kannst du es mit einem Lesezeichen versehen, indem du über in $(item)JEI$() ein Item auwählst und $(thing)A$() drückst. Dies fügt das Item der linken Seite hinzu, wo du es immer aufrufen kannst."
+		},
+		{
+			"type": "text",
+			"text": "Wenn du dir Notizen zu deinen nächsten Zielen machen, oder dir einfach etwas merken möchtest, versuche $(thing)N$() im Spiel zu drücken - dies öffnet ein neues $(item)Notizen$() Menü wo du dir alles mögliche aufschreiben kannst. Du kannst diese sogar an deinen Bildschirm anheften!"
+		},
+		{
+			"type": "text",
+			"text": "Nur als letzten Hinweis, viele Items haben ein $(thing)Info Tab$() angehängt, wenn man sie in $(item)JEI$() anklickt, also selbst wenn etwas so aussieht, als wäre es nicht hergestellt, oder wenn du nicht weißt, was es tut, erwäge, sein Rezept oder seine Verwendung zu überprüfen."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/matrix_enchanting.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/matrix_enchanting.json
@@ -1,0 +1,38 @@
+{
+	"name": "Matrix Enchanting",
+	"icon": "minecraft:enchanting_table",
+    "category": "patchouli:intro",
+    "read_by_default": false,
+    "advancement": "minecraft:story/form_obsidian",
+    "sortnum": 5,
+	"pages": [
+        {
+            "type": "text",
+            "text": "$(thing)Bliss$() verwendet ein neues Verzauberungssystem namens $(thing)Matrix Enchanting$(). Dieses System ermöglicht es dir, besser anzupassen, welche Verzauberungen du auf deine Werkzeuge legst, unter erhöhten EP- und Lapislazuli-Kosten.$(br2)Als Bonusfunktion behält der Tisch sowohl deinen Gegenstand als auch das Lapis darin, sehr nützlich."
+        },
+        {
+            "type": "image",
+            "images": [
+                "patchouli:matrix_enchanting.png"
+            ],
+            "title": "Verzauberung",
+            "border": true,
+            "text": "Der $(thing)Matrix Enchanting$() Bildschirm."
+        },
+        {
+            "type": "text",
+            "text": "Um mit dem Verzaubern anzufangen, platziere zunächst dein zu verzauberndes Item im oberen linken Feld, und dein Lapis in dem darunter.$(br2)Nun kannst du über die $(bold)+$() Schaltfläche eine neue Verzauberung hinzufügen. Die Verzauberung erscheint dann auf der Seite, was bedeutet du kannst sie wählen.$(br2)Um eine Verzauberung zu wählen wähle sie einfach im Seitenpanel mit der linken Maustaste, und positioniere sie auf dem 5x5 Feld."
+        },
+        {
+            "type": "text",
+            "text": "Wie zu erwarten, können Verzauberungs-\"Blöcke\" nicht übereinander liegen, also musst du vorsichtig sein, wie du sie platzierst. Du kannst dein ausgewähltes Teil drehen, indem du rechtsklickst.$(br2)Du darfst nicht mehrere Kopien derselben Verzauberung in einem Raster haben. Wenn Du die Stufe einer Verzauberung erhöhen möchtest, wähle ein Teil aus der Seitenleiste mit derselben Verzauberung aus und klicke es mit der linken Maustaste auf dasjenige, das Du bereits platziert hast."
+        },
+        {
+            "type": "text",
+            "text": "Je mehr du eine Verzauberung aufwertest, desto mehr Kopien desselben Blocks benötigst du natürlich.$(br2)Es ist wichtig, im Hinterkopf zu behalten, dass inkompatible Blöcke nicht angezeigt werden. Wenn Du also ein Schwert mit Schärfe anstrebst, kannst Du davon ausgehen, dass Du es nicht erhältst, wenn Du Bann hast.$(br2)Wenn du mit deiner Verzauberung fertig bist, ziehe einfach den verzauberten Gegenstand heraus."
+        },
+        {
+            "type": "patchouli:enchanting_influences"
+        }
+    ]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/mobs.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/mobs.json
@@ -1,0 +1,26 @@
+{
+	"name": "Mobs und Du",
+	"icon": "minecraft:iron_sword",
+	"sortnum": 2,
+	"priority": false,
+	"read_by_default": true,
+	"category": "patchouli:intro",
+	"pages": [
+		{
+			"type": "text",
+			"text": "Es folgen Erinnerungen zu den Informationen auf dem Bildschirm $(thing)Willkommen zu Bliss$(). Wisse, dass Monster...$(br)$(li)dich nicht angreifen werden, es sei denn, sie werden zuerst angegriffen.$(li)nicht auf Blöcken mit direkter Sicht zum Himmel spawnen, außer bei Gewitter.$(li)deine Welt nicht beschädigen werden (Creeper, Endermen usw)."
+		},
+		{
+			"type": "text",
+			"text": "Zusätzliche Änderungen am Spiel beinhalten...$(br)$(li)$(thing)Dorfbewohner$() werden auf $(item)Normal$() immer in $(thing)Zombie Dorfbewohner$() umgewandelt, anstatt zu sterben. $(li)$(thing)Spinnen$() spawnen nicht, und alle $(thing)Spinnen Spawner$() werden durch $(thing)Creeper Spawner$() ersetzt ($(thing)Höhlenspinnen Spawner$() immer noch auftauchen).$(li)$(thing)Feuerausbreitung$() ist deaktiviert.$(li)$(thing)Pillager Patrolien$() sind deaktiviert."
+		},
+		{
+			"type": "text",
+			"text": "Wenn Du es überwiegend entspannt haben möchtest, aber trotzdem eine Herausforderung haben möchtest, suche Dir eine $(item)Bastion$(), eine $(item)Wald-Villa$(), oder einen $(item)Pillager Außenposten$().$(br2)Diese Strukturen gelten als $(thing)bewacht$(), und als solche werden die Mobs darin immer noch aggressiv sein! $(br2)Beim erstmaligen Betreten wirst du daran erinnert, also mach dir nicht zu viele Gedanken darüber."
+		},
+		{
+			"type": "text",
+			"text": "Zu guter Letzt kannst du deinen Spielstil nach Belieben anpassen, indem du den Schwierigkeitsgrad deines Spiels änderst.$(br2)Auf $(li)Einfach$() erzeugen bewachte Strukturen keine Aggro mehr. $(li)Auf dem Schwierigkeitsgrad.. $(thing)Schwer$() gewinnen Mobs ihre natürliche Aggro-Fähigkeit zurück."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/movement.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/movement.json
@@ -1,0 +1,23 @@
+{
+	"name": "Bewegungs-Upgrades",
+	"icon": "minecraft:leather_boots",
+	"category": "patchouli:intro",
+    "read_by_default": false,
+    "advancement": "minecraft:story/upgrade_tools",
+    "sortnum": 4,
+	"pages": [
+        {
+            "type": "text",
+            "text": "In $(thing)Bliss$() stehen einige zusätzliche Bewegungsoptionen zur Verfügung:$(br)$(li) Das Drücken von $(thing)C$() erlaubt dir, $(thing)zu Boden zu gehen$(), wodurch du nur einen Block füllst.$(li)Während du neben einer Wand $(thing)schleichst$() (UMSCHALT), wirst du an der Wand greifen und von ihr rutschen, solange du mit ihr verbunden bist."
+        },
+		{
+            "type": "image",
+            "images": [
+                "patchouli:wall_jump.png"
+            ],
+            "title": "Wandsprünge",
+            "border": true,
+            "text": "Wenn Du springst, während Du an einer $(thing)Wand greifst$(), wirst Du einen $(thing)Wandsprung$() durchführen, der bis zu 3 Blöcke hoch gehen kann!"
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/starter_kit.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/starter_kit.json
@@ -1,0 +1,12 @@
+{
+	"name": "Starter Kit",
+	"icon": "minecraft:chest",
+	"category": "patchouli:intro",
+	"sortnum": 1,
+	"pages": [
+		{
+			"type": "text",
+			"text": "Wenn du nicht weißt, wie du mit $(thing)Bliss$() anfangen sollst, öffne deine $(thing)Suchleiste$(), und suche nach dem $(item)Starter Kit$(). Dir werden einige nützliche Items angezeigt die du dir vielleicht anschauen solltest.$(br2)Linksklicke einfach auf etwas, was dein Interesse weckt."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/towers.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/towers.json
@@ -1,0 +1,27 @@
+{
+	"name": "Türme der Wildnis",
+	"icon": "paraglider:paraglider",
+	"category": "patchouli:intro",
+	"read_by_default": false,
+	"advancement": "minecraft:adventure/sleep_in_bed",
+	"sortnum": 3,
+	"pages": [
+		{
+			"type": "text",
+			"text": "Über die ganze Welt verstreut wirst Du neue $(thing)Türme der Wildnis$() finden. Auf diesen hohen Strukturen befindet sich ein $(item)Wegstein$() sowie einige tolle Sachen zum Mitnehmen.$(br2)Mit $(item)Wegsteinen$() kann man sich sofort zwischen entdeckten Türmen teleportieren. Klicke einfach mit der rechten Maustaste auf einen $(thing)Wegstein$(), und wähle ein Ziel."
+		},
+        {
+            "type": "image",
+            "images": [
+                "patchouli:wild_towers.png"
+            ],
+            "title": "Türme der Wildnis",
+            "border": true,
+            "text": "Ein $(thing)Turm der Wildnis$(), und die Beute die Du aus einem solchen erhalten kannst."
+        },
+        {
+			"type": "text",
+			"text": "In der Truhe, die sich in jedem $(thing)Turm der Wildnis$() befindet, findet sich mindestens ein $(item)Parasegel$() - mit diesen kann man, wenn man sie hält, langsam nach unten gleiten und weite Strecken durch die Luft zurücklegen. $(br2)Zu guter Letzt beachte bitte, dass Du den $(item)Wegstein$() zwar zerbrechen kannst, aber $(l)nicht$() einsammeln kannst. Wenn Du das versuchst, wirst Du ihn nur zerstören, wie einen $(item)Monster Spawner$()."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/video_tutorial.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/video_tutorial.json
@@ -1,0 +1,17 @@
+{
+	"name": "Video Anleitungen",
+	"icon": "minecraft:music_disc_13",
+	"category": "patchouli:intro",
+    "read_by_default": true,
+    "priority": true,
+    "sortnum": 1,
+	"pages": [
+        {
+            "type": "text",
+            "text": "Wenn Du kein Lesertyp bist, kannst du mit $(thing)Bliss$() auch anfangen, indem Du dir die Videos dieser erstaunlichen Leute auf der nächsten Seite anschaust. $(br2)Das Video von $(thing)direwolf20$() ist eine kurze Starteranleitung mit Informationen, die du über das Modpack wissen solltest, und das Video von $(thing)Vallen$() ist eine Übersicht und Rezension. Bitte beachte, diese Videos sind auf Englisch."
+        },
+        {
+            "type": "patchouli:tubers"
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/welcome.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/welcome.json
@@ -1,0 +1,17 @@
+{
+	"name": "Willkommen zu Bliss",
+	"icon": "minecraft:writable_book",
+	"sortnum": 0,
+	"priority": true,
+	"category": "patchouli:intro",
+	"pages": [
+		{
+			"type": "text",
+			"text": "Willkommen zum $(thing)Bliss$() Modpack! Dieses Buch wird dich in die Grundlagen einführen, damit du anfangen kannst, Spaß zu haben."
+		},
+		{
+			"type": "text",
+			"text": "Die in dem Buch enthaltenen Informationen sind speziell darauf ausgelegt, kurz und bündig zu sein, damit Du nicht zu lange hier bleiben musst, also pass bitte auf! $(br2)Dein Spiel wird pausiert, während du hier bist, wenn du im Einzelspieler bist."
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/intro/wither_changes.json
+++ b/patchouli_books/blissguide/de_de/entries/intro/wither_changes.json
@@ -1,0 +1,18 @@
+{
+	"name": "Wither Änderungen",
+	"icon": "minecraft:wither_skeleton_skull",
+	"category": "patchouli:intro",
+    "read_by_default": false,
+    "advancement": "minecraft:nether/get_wither_skull",
+    "sortnum": 6,
+	"pages": [
+        {
+            "type": "text",
+            "text": "Um den $(thing)Wither$() ein bisschen weniger einschüchternd zu machen, stellt dir $(thing)Bliss$() eine neue Waffe zur Verfügung: $(thing)Schneegolems$(). $(br2)Du hast richtig gehört. $(thing)Schneegolems$() sind jetzt super effektiv gegen den $(thing)Wither$(). Eine Armee von denen macht kurzen Prozess mit dem Monster! Beachte, dass der $(thing)Wither$() immer noch Terrain zerstört, also sei vorsichtig, wo du ihn spawnst!"
+        },
+        {
+            "type": "text",
+            "text": "Außerdem wird der $(thing)Wither$()-Kampf basierend auf der Schwierigkeitseinstellung deines Spiels geändert: $(br)$(li)Auf $(thing)Einfach$() spawnt er überhaupt nicht, und stattdessen wirst du einfach einen $(item)Netherstern$() für das Bauen der Struktur erhalten.$(li)Auf $(thing)Schwierig$() wird der Boss seine Immunität gegen Schnee wiedererlangen, also musst du ihn richtig bekämpfen."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/campire_boost.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/campire_boost.json
@@ -1,0 +1,14 @@
+{
+	"name": "Lagerfeuer Auftrieb",
+	"icon": "minecraft:campfire",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:campfire",
+            "title": "Lagerfeuer Auftrieb",
+            "text": "Wenn du mit $(item)Elytren$() über ein $(item)Lagerfeuer$() mit einer $(item)Strohballenbasis$() fliegst wirst du kurz einen großen Auftrieb erhalten. $(br2)$(item)Seelenlagerfeuer$() haben den umgekehrten Effekt, sie ziehen dich nach unten!"
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/chain_features.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/chain_features.json
@@ -1,0 +1,14 @@
+{
+	"name": "Verkettete Bewegung",
+	"icon": "minecraft:chain",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:chain",
+            "title": "Verkettete Bewegung",
+            "text": "Wenn sie von $(item)Kolben$() verschoben werden, können $(item)Ketten$() mehrere Blöcke miteinander verbinden, wenn sie zwischen ihnen platziert werden."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/compass_everywhere.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/compass_everywhere.json
@@ -1,0 +1,14 @@
+{
+	"name": "Kompasse überall",
+	"icon": "minecraft:compass",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:compass",
+            "title": "Kompasse überall",
+            "text": "$(item)Kompasse$() können jetzt im $(thing)Nether$() und im $(thing)End$() verwendet werden. Sie zeigen entweder auf das Portal durch das du den $(thing)Nether$() betreten hast, oder auf das Portal um das $(thing)End$() zu verlassen."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/customizable_bed.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/customizable_bed.json
@@ -1,0 +1,14 @@
+{
+	"name": "Anpassbare Betten",
+	"icon": "minecraft:red_bed",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:red_bed",
+            "title": "Anpassbare Betten",
+            "text": "$(item)Betten$() können jetzt mit $(item)Bannern$() angepasst werden, sodass Du deinen Wohnraum noch mehr dekorieren kannst."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/dispenser_block_placing.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/dispenser_block_placing.json
@@ -1,0 +1,14 @@
+{
+	"name": "Werfer sind Platzierer",
+	"icon": "minecraft:dispenser",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:dispenser",
+            "title": "Werfer sind Platzierer",
+            "text": "$(item)Werfer$() können nun Blöcke platzieren. Die Blöcke werden sogar in der richtigen Orientierung platziert!"
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/enhanced_banners.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/enhanced_banners.json
@@ -1,0 +1,14 @@
+{
+	"name": "Verbesserte Banner",
+	"icon": "minecraft:pink_banner",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:pink_banner",
+            "title": "Verbesserte Banner",
+            "text": "$(item)Banner$() können nun zusätzlich zu Wänden und Böden auch an der Decke befestigt werden. $(br2)$(item)Banner Muster$() können nun außerdem 16 Lagen haben, statt der 6 des Grundspiels."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/hoe_harvesting.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/hoe_harvesting.json
@@ -1,0 +1,14 @@
+{
+	"name": "Ernten mit der Hacke",
+	"icon": "minecraft:diamond_hoe",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:diamond_hoe",
+            "title": "Ernten mit der Hacke",
+            "text": "$(item)Hacken$() können verwendet werden um ein 3x3 Feld Angebautes abzubauen. $(item)Diamant$() und $(thing)Netherit Hacken$() sogar ein 5x5 Feld abbauen. $(br2)Darüber hinaus kannst du eine Pflanze rechtsklicken um sie zu ernten und neu zu pflanzen. Mit einer $(item)Hacke$() wird der entsprechende Bereich geerntet."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/improved_ladders.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/improved_ladders.json
@@ -1,0 +1,14 @@
+{
+	"name": "Verbesserte Leitern",
+	"icon": "minecraft:ladder",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:ladder",
+            "title": "Verbesserte Leitern",
+            "text": "$(item)Leitern$() können jetzt heruntergelassen werden, indem man mit der rechten Maustaste auf eine platzierte Leiter mit einer anderen klickt. Dadurch können Leitern frei stehen, ohne dass ein Block dahinter liegt. $(br2)Du kannst auch schnell nach unten rutschen, indem du nach unten schaust."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/jukebox_automation.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/jukebox_automation.json
@@ -1,0 +1,14 @@
+{
+	"name": "Automatische Plattenspieler",
+	"icon": "minecraft:jukebox",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:jukebox",
+            "title": "Automatische Plattenspieler",
+            "text": "$(item)Plattenspieler$() können jetzt automatisch Musik abspielen, indem man die $(item)Schallplatte$() mit einem $(item)Werfer$() einlegt. Zum Herausnehmen der Platte kann ein $(item)Trichter$() unten angebracht werden."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/lilypad_topping.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/lilypad_topping.json
@@ -1,0 +1,14 @@
+{
+	"name": "Seerosenblatt-Topping",
+	"icon": "minecraft:lily_pad",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:lily_pad",
+            "title": "Seerosenblatt-Topping",
+            "text": "Blöcke können nun auf $(item)Seerosenblättern$() platziert werden. Probier es zum Beispiel mit $(item)Fackeln$() aus."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/map_decorations.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/map_decorations.json
@@ -1,0 +1,18 @@
+{
+	"name": "Kartendekorationen",
+	"icon": "minecraft:filled_map",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:filled_map",
+            "title": "Kartendekorationen",
+            "text": "Dekorationen können deinen $(item)Karten$() hinzugefügt werden. $(br2)Wenn du mit einer Karte einen der folgenden Gegenstände rechtsklickst wird dieser deiner Karte hinzugefügt:"
+        },
+		{
+			"type": "text",
+			"text": "$(br2)Es folgt eine Liste der Dekogegenstände: $(li)$(item)Leuchtfeuer$() $(li)$(item)Leitstein$() $(li)$(item)Seelenanker$() $(li)$(item)Bett$() $(li)$(item)Aquisator$() $(li)$(item)Portal$() $(li)$(item)Wegweiser$()"			
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/pig_litters.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/pig_litters.json
@@ -1,0 +1,14 @@
+{
+	"name": "Schweinewürfe",
+	"icon": "minecraft:porkchop",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+    "pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:porkchop",
+            "title": "Schweinewürfe",
+            "text": "Wenn Du $(thing)Schweine$() züchtest, bekommst Du jetzt einen kleinen Wurf Babys, was das Schwein zu einer relevanteren Nahrungsquelle macht."
+        }
+    ]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/piston_buffs.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/piston_buffs.json
@@ -1,0 +1,14 @@
+{
+	"name": "Verstärkte Kolben",
+	"icon": "minecraft:piston",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:piston",
+            "title": "Verstärkte Kolben",
+            "text": "$(item)Kolben$() können nun doppelt so viele Blöcke wie zuvor schieben, also bis zu 24 Blöcke. Sie sind außerdem in der Lage $(thing)Tile Entities$() zu verschieben, zum Beispiel $(item)Kisten$(), $(item)Öfen$(), usw.$(br2)Wenn du einen unbeweglichen Block brauchst, $(item)Fester Stein$() eignet sich hierzu hervorragend."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/placeable_items.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/placeable_items.json
@@ -1,0 +1,14 @@
+{
+	"name": "Platzierbare Items",
+	"icon": "minecraft:stick",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:stick",
+            "title": "Platzierbare Items",
+            "text": "Die folgenden Gegenstände können nun platziert werden: $(li)$(item)Stöcke$()$(li)$(item)Lohenruten$()$(li)$(item)Schwarzpulver$()$(li)$(item)Bücher$()$(br2)$(item)Schwarzpulver$() kann selbstverständlich auch angezündet werden, und wird von alleine naheliegendes $(item)TNT$() entzünden.$(br2)Du kannst auch nach $(thing)Placeable$() in deiner Suchleiste suchen."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/pot_all_the_things.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/pot_all_the_things.json
@@ -1,0 +1,14 @@
+{
+	"name": "Topfe alles ein!",
+	"icon": "minecraft:flower_pot",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:flower_pot",
+            "title": "Topfe alles ein!",
+            "text": "$(item)Blumentöpfe$() können jetzt tonnenweise mehr Blumen und Feldfrüchte aufnehmen. $(br2)Du kannst sie auch an der Decke oder an $(item)Ketten$() aufhängen."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/soul_candles.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/soul_candles.json
@@ -1,0 +1,14 @@
+{
+	"name": "Seelenkerzen",
+	"icon": "minecraft:purple_candle",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:purple_candle",
+            "title": "Seelenkerzen",
+            "text": "Wenn du $(item)Seelensand$() oder einen anderen $(item)Seelenfeuer$() erzeugenden Block unter einer $(item)Kerze$() platzierst wird diese mit einer blauen Seelenfeuerflamme brennen, anstatt der normalen orangen."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/useful_curses.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/useful_curses.json
@@ -1,0 +1,14 @@
+{
+	"name": "Nützliche Flüche",
+	"icon": "minecraft:carved_pumpkin",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:carved_pumpkin",
+            "title": "Nützliche Flüche",
+            "text": "$(thing)Fluch Verzauberungen$() haben nun einige Nutzen: $(li)$(item)Geschnitzte Kürbisse$() mit $(thing)Fluch des Verschwindens$() werden beim Tragen dein Sichtfeld nicht beeinträchtigen.$(li)Ein benannter $(item)Spielerkopf$() welcher mit $(thing)Fluch der Bindung$() verzaubert wurde wird nun den gesamten Skin des Spielers zeigen wenn er auf einem $(item)Rüstungsständer$() platziert wird."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/villager_herding.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/villager_herding.json
@@ -1,0 +1,14 @@
+{
+	"name": "Dorfbewohner Transport",
+	"icon": "minecraft:emerald_block",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:emerald_block",
+            "title": "Dorfbewohner Transport",
+            "text": "$(thing)Dorfbewohner$() werden nun Spielern folgen die einen $(item)Smaragdblock$() halten, was es einfacher macht sie zu transportieren."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/entries/vanilla_changes/wall_lanterns.json
+++ b/patchouli_books/blissguide/de_de/entries/vanilla_changes/wall_lanterns.json
@@ -1,0 +1,14 @@
+{
+	"name": "Wandlaternen",
+	"icon": "minecraft:lantern",
+	"category": "patchouli:vanilla_changes",
+    "read_by_default": true,
+	"pages": [
+        {
+            "type": "spotlight",
+            "item": "minecraft:lantern",
+            "title": "Wandlaternen",
+            "text": "$(thing)Laternen$() können nun an Wänden, $(item)Wegweisern$() sowie $(item)Ketten$() befestigt werden."
+        }
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/enchanting_influences.json
+++ b/patchouli_books/blissguide/de_de/templates/enchanting_influences.json
@@ -1,0 +1,23 @@
+{
+	"include": [
+	    {
+	        "template": "patchouli:incl/candles",
+	        "as": "incl",
+	    	"x": 12,
+	    	"y": 15
+	    }
+	],
+	"components": [
+		{
+			"type": "patchouli:header",
+			"text": "Candle Influences",
+			"x": -1,
+			"y": -1
+		},
+		{
+			"type": "patchouli:text",
+			"text": "Bis zu 4 Kerzen eines Typ können verwendet werden um spezifische Verzauberungen häufiger erscheinen zu lassen.",
+			"y": 110
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/gossip_book.json
+++ b/patchouli_books/blissguide/de_de/templates/gossip_book.json
@@ -1,0 +1,23 @@
+{
+	"include": [
+	    {
+	        "template": "patchouli:incl/gossip_base",
+	        "as": "base",
+	        "using": {
+	        	"title": "#title",
+	        	"text": "#text"
+	        }
+	    }
+	],
+	"components": [
+		{
+			"type": "patchouli:image",
+			"x": 1,
+			"y": 73,
+			"width": 138,
+			"height": 150,
+			"scale": 0.5,
+			"image": "patchouli:lissa_book.png"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/gossip_camera.json
+++ b/patchouli_books/blissguide/de_de/templates/gossip_camera.json
@@ -1,0 +1,23 @@
+{
+	"include": [
+	    {
+	        "template": "patchouli:incl/gossip_base",
+	        "as": "base",
+	        "using": {
+	        	"title": "#title",
+	        	"text": "#text"
+	        }
+	    }
+	],
+	"components": [
+		{
+			"type": "patchouli:image",
+			"x": 54,
+			"y": 75,
+			"width": 118,
+			"height": 147,
+			"scale": 0.5,
+			"image": "patchouli:lissa_camera.png"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/gossip_explore.json
+++ b/patchouli_books/blissguide/de_de/templates/gossip_explore.json
@@ -1,0 +1,23 @@
+{
+	"include": [
+	    {
+	        "template": "patchouli:incl/gossip_base",
+	        "as": "base",
+	        "using": {
+	        	"title": "#title",
+	        	"text": "#text"
+	        }
+	    }
+	],
+	"components": [
+		{
+			"type": "patchouli:image",
+			"x": 28,
+			"y": 75,
+			"width": 165,
+			"height": 148,
+			"scale": 0.5,
+			"image": "patchouli:lissa_explore.png"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/gossip_game.json
+++ b/patchouli_books/blissguide/de_de/templates/gossip_game.json
@@ -1,0 +1,23 @@
+{
+	"include": [
+	    {
+	        "template": "patchouli:incl/gossip_base",
+	        "as": "base",
+	        "using": {
+	        	"title": "#title",
+	        	"text": "#text"
+	        }
+	    }
+	],
+	"components": [
+		{
+			"type": "patchouli:image",
+			"x": 4,
+			"y": 72,
+			"width": 140,
+			"height": 164,
+			"scale": 0.5,
+			"image": "patchouli:lissa_game.png"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/gossip_love.json
+++ b/patchouli_books/blissguide/de_de/templates/gossip_love.json
@@ -1,0 +1,23 @@
+{
+	"include": [
+	    {
+	        "template": "patchouli:incl/gossip_base",
+	        "as": "base",
+	        "using": {
+	        	"title": "#title",
+	        	"text": "#text"
+	        }
+	    }
+	],
+	"components": [
+		{
+			"type": "patchouli:image",
+			"x": 4,
+			"y": 72,
+			"width": 218,
+			"height": 145,
+			"scale": 0.5,
+			"image": "patchouli:lissa_love.png"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/incl/candles.json
+++ b/patchouli_books/blissguide/de_de/templates/incl/candles.json
@@ -1,0 +1,345 @@
+{
+	"components": [
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:white_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:unbreaking"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 0,
+			"y": 0
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:orange_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:fire_protection"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 24,
+			"y": 0
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:magenta_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:knockback"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:punch"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 48,
+			"y": 0
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:light_blue_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:feather_falling"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 72,
+			"y": 0
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:yellow_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:looting"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:fortune"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:luck_of_the_sea"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 0,
+			"y": 24
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:lime_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:blast_protection"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 24,
+			"y": 24
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:pink_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:silk_touch"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:channeling"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 48,
+			"y": 24
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:gray_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "farmersdelight:backstabbing"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 72,
+			"y": 24
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:light_gray_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:protection"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 0,
+			"y": 48
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:cyan_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:respiration"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:loyalty"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:infinity"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 24,
+			"y": 48
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:purple_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:sweeping"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:multishot"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 48,
+			"y": 48
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:blue_candle",
+				"nbt": {
+					"quark:no_tooltip": true,
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:efficiency"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:sharpness"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:lure"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:power"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:impaling"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:quick_charge"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 72,
+			"y": 48
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:brown_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:aqua_affinity"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:depth_strider"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:riptide"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 0,
+			"y": 72
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:green_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:thorns"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:piercing"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 24,
+			"y": 72
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:red_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:fire_aspect"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:flame"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 48,
+			"y": 72
+		},
+		{
+			"type": "patchouli:item",
+			"item": {
+				"item": "minecraft:black_candle",
+				"nbt": {
+					"Enchantments": [
+						{
+							"lvl": 1,
+							"id": "minecraft:smite"
+						},
+						{
+							"lvl": 1,
+							"id": "minecraft:projectile_protection"
+						}
+					]
+				}
+			},
+			"framed": true,
+			"x": 72,
+			"y": 72
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/incl/gossip_base.json
+++ b/patchouli_books/blissguide/de_de/templates/incl/gossip_base.json
@@ -1,0 +1,29 @@
+{
+	"components": [
+		{
+			"type": "patchouli:header",
+			"centered": true,
+			"x": -1,
+			"y": -1,
+			"text": "#title"
+		},
+		{
+			"type": "patchouli:separator",
+			"x": -1,
+			"y": -1
+		},
+		{
+			"type": "patchouli:header",
+			"centered": false,
+			"x": 0,
+			"y": 20,
+			"color": "fe84a3",
+			"text": "Wusstest du..."
+		},
+		{
+			"type": "patchouli:text",
+			"text": "#text",
+			"y": 30
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/incl/tuber.json
+++ b/patchouli_books/blissguide/de_de/templates/incl/tuber.json
@@ -1,0 +1,36 @@
+{
+	"components": [
+		{
+			"type": "patchouli:image",
+			"x": 10,
+			"y": 30,
+			"u": 0,
+			"v": 0,
+			"width": 64,
+			"height": 64,
+			"texture_width": 128,
+			"texture_height": 128,
+			"scale": 0.5,
+			"image": "patchouli:#texture#.png"
+		},
+		{
+			"type": "patchouli:header",
+			"centered": false,
+			"x": 45,
+			"y": 34,
+			"text": "#name"
+		},
+		{
+			"type": "patchouli:text",
+			"x": 52,
+			"y": 41,
+			"text": "#desc"
+		},
+		{
+			"type": "patchouli:text",
+			"x": 45,
+			"y": 50,
+			"text": "$(c)>$() $(l:https://www.youtube.com/watch?v=#video_id#)$(underline)WATCH$()"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/lissa_full.json
+++ b/patchouli_books/blissguide/de_de/templates/lissa_full.json
@@ -1,0 +1,30 @@
+{
+	"components": [
+		{
+			"type": "patchouli:image",
+			"x": 6,
+			"y": -5,
+			"width": 159,
+			"height": 301,
+			"texture_width": 256,
+			"texture_height": 512,
+			"scale": 0.5,
+			"image": "patchouli:lissa_full.png"
+		},
+		{
+			"type": "patchouli:header",
+			"centered": false,
+			"x": 66,
+			"y": 9,
+			"color": "fe84a3",
+			"text": "Lissa!"
+		},
+		{
+			"type": "patchouli:text",
+			"x": 76,
+			"y": 17,
+			"color": "fe84a3",
+			"text": "she/they"
+		}
+	]
+}

--- a/patchouli_books/blissguide/de_de/templates/tubers.json
+++ b/patchouli_books/blissguide/de_de/templates/tubers.json
@@ -1,0 +1,45 @@
+{
+	"include": [
+	    {
+	        "template": "patchouli:incl/tuber",
+	        "as": "direwolf20",
+	        "using": {
+				"texture": "direwolf20",
+	        	"name": "direwolf20",
+	        	"desc": "Starter Guide",
+	        	"video_id": "QZ6uO32ED9I"
+	        }
+	    },
+	    {
+	        "template": "patchouli:incl/tuber",
+	        "as": "vallen",
+	        "y": 40,
+	        "using": {
+				"texture": "mom",
+	        	"name": "Vallen",
+	        	"desc": "Pack Overview",
+	        	"video_id": "FXFdRJPNrM4"
+	        }
+	    }
+	],
+	"components": [
+		{
+			"type": "patchouli:header",
+			"centered": true,
+			"x": -1,
+			"y": -1,
+			"text": "Videos"
+		},
+		{
+			"type": "patchouli:separator",
+			"x": -1,
+			"y": -1
+		},
+		{
+			"type": "patchouli:text",
+			"x": 0,
+			"y": 110,
+			"text": "Als Streamer kannst du die Videos auch im Stream ansehen. Wir haben kein Problem damit."
+		}
+	]
+}


### PR DESCRIPTION
added a German version of the blissguide.
every entry is translated, with small changes to layout and exact meaning to make it fit in the pages.
This version is NOT perfect. It works.

I allow you to use and edit this translation, if necessary.